### PR TITLE
Containerfiles and definition template for Docker Official Library

### DIFF
--- a/Containerfiles/8/Containerfile.default
+++ b/Containerfiles/8/Containerfile.default
@@ -1,0 +1,4 @@
+# Tags: 8, 8.9, 8.9-20231124
+FROM quay.io/almalinuxorg/almalinux:8.9-20231124
+
+CMD ["/bin/bash"]

--- a/Containerfiles/8/Containerfile.minimal
+++ b/Containerfiles/8/Containerfile.minimal
@@ -1,0 +1,4 @@
+# Tags: 8-minimal, 8.9-minimal, 8.9-minimal-20231124
+FROM quay.io/almalinuxorg/8-minimal:8.9-20231124
+
+CMD ["/bin/bash"]

--- a/Containerfiles/9/Containerfile.default
+++ b/Containerfiles/9/Containerfile.default
@@ -1,0 +1,4 @@
+# Tags: latest, 9, 9.3, 9.3-20231124
+FROM quay.io/almalinuxorg/almalinux:9.3-20231124
+
+CMD ["/bin/bash"]

--- a/Containerfiles/9/Containerfile.minimal
+++ b/Containerfiles/9/Containerfile.minimal
@@ -1,0 +1,4 @@
+# Tags: minimal, 9-minimal, 9.3-minimal, 9.3-minimal-20231124
+FROM quay.io/almalinuxorg/9-minimal:9.3-20231124
+
+CMD ["/bin/bash"]

--- a/docker-library-definition.tmpl
+++ b/docker-library-definition.tmpl
@@ -1,0 +1,5 @@
+Tags: {{ .tags }}
+GitFetch: refs/heads/docker-library
+GitCommit: {{ .commit_hash }}
+File: Containerfiles/{{ .version_major }}/Containerfile.{{ .image_type }}
+Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
Add docker library Containerfile(s) for AlmaLinux versions 8 and 9, and following types: default, minimal.

Add template with "block of code" to generate Docker Library definition file: official-images/library/almalinux