### PR TITLE
The branch for AlmaLinux  to store Dockerfiles and root file-systems

### DIFF
--- a/default/amd64/Dockerfile
+++ b/default/amd64/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: latest, 9, 9.3, 9.3-20231124
+FROM scratch
+ADD almalinux-9-default-amd64.tar.xz /
+
+CMD ["/bin/bash"]

--- a/default/arm64/Dockerfile
+++ b/default/arm64/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: latest, 9, 9.3, 9.3-20231124
+FROM scratch
+ADD almalinux-9-default-arm64.tar.xz /
+
+CMD ["/bin/bash"]

--- a/default/ppc64le/Dockerfile
+++ b/default/ppc64le/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: latest, 9, 9.3, 9.3-20231124
+FROM scratch
+ADD almalinux-9-default-ppc64le.tar.xz /
+
+CMD ["/bin/bash"]

--- a/default/s390x/Dockerfile
+++ b/default/s390x/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: latest, 9, 9.3, 9.3-20231124
+FROM scratch
+ADD almalinux-9-default-s390x.tar.xz /
+
+CMD ["/bin/bash"]

--- a/docker-library-definition.tmpl
+++ b/docker-library-definition.tmpl
@@ -1,0 +1,8 @@
+Tags: {{ .tags }}
+GitFetch: refs/heads/{{ .version_major }}
+GitCommit: {{ .commit_hash }}
+amd64-Directory: {{ .image_type }}/amd64/
+arm64v8-Directory: {{ .image_type }}/arm64/
+ppc64le-Directory: {{ .image_type }}/ppc64le/
+s390x-Directory: {{ .image_type }}/s390x/
+Architectures: amd64, arm64v8, ppc64le, s390x

--- a/minimal/amd64/Dockerfile
+++ b/minimal/amd64/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: minimal, 9-minimal, 9.3-minimal, 9.3-minimal-20240405
+FROM scratch
+ADD almalinux-9-minimal-amd64.tar.xz /
+
+CMD ["/bin/bash"]

--- a/minimal/arm64/Dockerfile
+++ b/minimal/arm64/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: minimal, 9-minimal, 9.3-minimal, 9.3-minimal-20240405
+FROM scratch
+ADD almalinux-9-minimal-arm64.tar.xz /
+
+CMD ["/bin/bash"]

--- a/minimal/ppc64le/Dockerfile
+++ b/minimal/ppc64le/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: minimal, 9-minimal, 9.3-minimal, 9.3-minimal-20240405
+FROM scratch
+ADD almalinux-9-minimal-ppc64le.tar.xz /
+
+CMD ["/bin/bash"]

--- a/minimal/s390x/Dockerfile
+++ b/minimal/s390x/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: minimal, 9-minimal, 9.3-minimal, 9.3-minimal-20240405
+FROM scratch
+ADD almalinux-9-minimal-s390x.tar.xz /
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
These Dockerfile(s) and the RootFS(s) are used to request Docker Official images building.