### PR TITLE
Implement root file-system extracting from images.

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -57,13 +57,13 @@ env:
   # Platforms list: linux/amd64, linux/ppc64le, linux/s390x, linux/arm64
   platforms: 'linux/amd64, linux/ppc64le, linux/s390x, linux/arm64'
 
-  # Registries list
-  # production: docker.io/almalinux, quay.io/almalinuxorg, ghcr.io/almalinux
-  # testing: quay.io/almalinuxautobot
+  # Registries list:
+  # for production: docker.io/almalinux, quay.io/almalinuxorg, ghcr.io/almalinux
+  # for testing: quay.io/almalinuxautobot
   registries: ${{ inputs.production && 'docker.io/almalinux, quay.io/almalinuxorg, ghcr.io/almalinux' || 'quay.io/almalinuxautobot, ghcr.io/almalinux' }}
 
 jobs:
-  build:
+  build-test-push:
     name: Deploy ${{ inputs.version_major }} ${{ matrix.image_types }} images
     runs-on: ubuntu-latest
     strategy:
@@ -150,11 +150,11 @@ jobs:
         uses: actions/checkout@v4
 
       -
-        name: Checkout ${{ github.repository }}, branch 'docker-library', path 'docker-library'
+        name: Checkout ${{ github.repository }}, branch 'docker-library', path '${{ inputs.version_major }}'
         uses: actions/checkout@v4
         with:
-          ref: docker-library
-          path: docker-library
+          ref: ${{ inputs.version_major }}
+          path: ${{ inputs.version_major }}
 
       -
         name: Set up QEMU
@@ -245,83 +245,123 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Change date stamp in 'docker-library/Containerfiles/*/Containerfile.*'
       -
-        name: Change date stamp in Containerfile (default and minimal only)
+        name: Extract RootFS (default and minimal only)
+        id: extract-rootfs
         # 'default' or 'minimal' images only go to Docker Official Library
         if: matrix.image_types == 'default' || matrix.image_types == 'minimal'
         run: |
-          containerfile=docker-library/Containerfiles/${{ inputs.version_major }}/Containerfile.${{ matrix.image_types }}
+          # [RootFS]
 
-          case ${{ matrix.image_types }} in
-            default)
-              tags="${{ inputs.version_major }}, ${{ inputs.version_major }}.${{ env.version_minor }}, ${{ inputs.version_major }}.${{ env.version_minor }}-${{ env.date_stamp }}"
-              [ "${{ inputs.version_major }}" = "9" ] && tags="latest, ${tags}" ;;
-            minimal)
-              tags="${{ inputs.version_major }}-${{ matrix.image_types }}, ${{ inputs.version_major }}.${{ env.version_minor }}-${{ matrix.image_types }}, ${{ inputs.version_major }}.${{ env.version_minor }}-${{ matrix.image_types }}-${{ env.date_stamp }}"
-              [ "${{ inputs.version_major }}" = "9" ] && tags="minimal, ${tags}" ;;
-            *)
-          esac
+          # File name for RootFS file (packed with tag + Xz)
+          name=almalinux-${{ inputs.version_major }}-${{ matrix.image_types }}
+          pwd=$( pwd )
+          path=${pwd}/${name}
 
-          # Tags: 8, 8.9, 8.9-20231124
-          sed -i "/^\([[:space:]]*#[[:space:]]*Tags: \).*/s//\1${tags}/" ${containerfile}
+          # The "tar file" for 'docker save' to write to
+          tar_name=${pwd}/${name}.tar
 
-          # FROM quay.io/almalinuxorg/almalinux:8.9-20231124
-          sed -i 's/^\([[:space:]]*FROM[[:space:]]\+.\+:\).\+$/\1${{ inputs.version_major }}.${{ env.version_minor }}-${{ env.date_stamp}}/' ${containerfile}
+          mkdir ${path}
+          cd ${path}
 
-          # [Debug]
-          cat ${containerfile}
+          # Produce a tarred repository and save it to the "tar file".
+          docker save ${{ steps.build-images.outputs.digest }} -o ${tar_name}
 
-      # Upload changed 'Containerfiles/*/Containerfile.*'
+          # Extract the "tar file"
+          tar xf ${tar_name}
+          cd blobs/sha256
+
+          # The "temporary Dockerfile" to build image based on RootFS
+          cat <<EOF > Dockerfile
+          FROM scratch
+          ADD rootfs.tar.gz /
+          CMD ["/bin/bash"]
+          EOF
+
+          # Loop blobs to find all zipped files that are RootFS for a particular architecture
+          for file in `find . -type f`; do
+            if file --brief ${file} | grep -i gzip >/dev/null; then
+              # Make a copy of "taken RootFS"
+              cp -av ${file} rootfs.tar.gz
+
+              # Build an image from the "temporary Dockerfile"
+              docker build -t rootfs .
+
+              # Run the image and query almalinux-release package's architecture
+              arch=$( docker run --rm rootfs /bin/bash -c "rpm -q --qf=%{ARCH} almalinux-release" )
+
+              # Map found architecture to the corresponding platform
+              platform=
+              docker rmi rootfs
+              case ${arch} in
+                x86_64)
+                  platform=amd64;;
+                ppc64le)
+                  platform=ppc64le;;
+                s390x)
+                  platform=s390x;;
+                aarch64)
+                  platform=arm64;;
+                *)
+                  echo "The '$arch' is incorrect or failed to determine architecture." && false;;
+              esac
+
+              # Delete copy of the "taken RootFS"
+              rm -f rootfs.tar.gz
+
+              # Copy the "taken RootFS" into corresponded .tar.xz
+              cp -av ${file} ${name}-${platform}.tar.gz
+              zcat ${name}-${platform}.tar.gz | xz -9 -e -T0 > ${pwd}/${{ inputs.version_major }}/${{ matrix.image_types }}/${platform}/${name}-${platform}.tar.xz
+
+            fi
+          done
+
+          # Clean up
+          rm -rf ${path}
+
+          echo "[Debug]"
+          ls -1 ${pwd}/${{ inputs.version_major }}/${{ matrix.image_types }}/*/*.tar.xz
+
+      # Change date stamp in '${version_major}/${image_types}/${arch}/Dockerfile'
       -
-        name: Upload changed Containerfile (default and minimal only)
-        uses: actions/upload-artifact@v4
+        name: Change date stamp in Dockerfile (default and minimal only)
         # 'default' or 'minimal' images only go to Docker Official Library
         if: matrix.image_types == 'default' || matrix.image_types == 'minimal'
-        with:
-          name: containerfiles-${{ matrix.image_types }}
-          path: docker-library/Containerfiles/${{ inputs.version_major }}/Containerfile.${{ matrix.image_types }}
-
-    outputs:
-      date_stamp: ${{ steps.date_stamp.outputs.date_stamp }}
-
-  commit:
-    # 'default' or 'minimal' images only go to Docker Official Library
-    if: inputs.type_default || inputs.type_minimal
-    name: Collect and save changed Containerfile(s) used by Docker Official Library
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    steps:
-
-      -
-        name: Checkout ${{ github.repository }}, branch 'docker-library'
-        uses: actions/checkout@v4
-        with:
-          ref: docker-library
-
-      # Download uploaded above 'Containerfiles/*/Containerfile.*'
-      -
-        name: Download changed Containerfiles
-        uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-          path: Containerfiles/${{ inputs.version_major }}
-
-      -
-        name: "[Debug] Print Containerfiles/${{ inputs.version_major }}/Containerfile.*"
         run: |
-          # [Debug]
-          cat Containerfiles/${{ inputs.version_major }}/Containerfile.*
+          # [Dockerfile]
 
-      # Commit 'Containerfiles/*/Containerfile.*'
+          platforms="${{ env.platforms }}"
+          for platform in ${platforms//,/ }; do
+            arch=${platform#linux/}
+            dockerfile=${{ inputs.version_major }}/${{ matrix.image_types }}/${arch}/Dockerfile
+
+            case ${{ matrix.image_types }} in
+              default)
+                tags="${{ inputs.version_major }}, ${{ inputs.version_major }}.${{ env.version_minor }}, ${{ inputs.version_major }}.${{ env.version_minor }}-${{ env.date_stamp }}"
+                [ "${{ inputs.version_major }}" = "9" ] && tags="latest, ${tags}" ;;
+              minimal)
+                tags="${{ inputs.version_major }}-${{ matrix.image_types }}, ${{ inputs.version_major }}.${{ env.version_minor }}-${{ matrix.image_types }}, ${{ inputs.version_major }}.${{ env.version_minor }}-${{ matrix.image_types }}-${{ env.date_stamp }}"
+                [ "${{ inputs.version_major }}" = "9" ] && tags="minimal, ${tags}" ;;
+              *)
+            esac
+
+            # Tags: 8, 8.9, 8.9-20231124
+            sed -i "/^\([[:space:]]*#[[:space:]]*Tags: \).*/s//\1${tags}/" ${dockerfile}
+
+            echo "[Debug] ${dockerfile}"
+            cat ${dockerfile}
+          done
+
+      # Commit '${version_major}/${image_types}/${arch}/*'
       -
-        name: "Commit and push Containerfiles/${{ inputs.version_major }}/Containerfile.* changes"
-        # if 'Push to production' is checked
-        if: inputs.production
+        name: "Commit and push ${{ matrix.image_types }}/*/* Dockerfile and RootFS (branch ${{ inputs.version_major }})"
+        # 'default' or 'minimal' images only and 'Push to production' is checked
+        if: ( matrix.image_types == 'default' || matrix.image_types == 'minimal' ) && inputs.production
         uses: EndBug/add-and-commit@v9
         with:
           default_author: user_info
-          new_branch: docker-library
-          message: "AlmaLinux ${{ inputs.version_major }} image built as of ${{ needs.build.outputs.date_stamp }} (generated on ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          new_branch: ${{ inputs.version_major }}
+          cwd: ${{ inputs.version_major }}
+          pull: '--rebase --autostash'
+          message: "AlmaLinux ${{ inputs.version_major }} ${{ matrix.image_types }} image built as of ${{ env.date_stamp }} (generated on ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           push: true

--- a/.github/workflows/publish-docker-library.yml
+++ b/.github/workflows/publish-docker-library.yml
@@ -19,6 +19,8 @@ env:
   docker_library: docker-library/official-images
   # Docker Library Git repository name (local fork): ${{ github.actor }}/official-images or almalinux/docker-library-official-images
   local_library: almalinux/docker-library-official-images
+  # Docker Library Git repository owner (local fork): ${{ github.actor }} or almalinux
+  library_owner: almalinux
 
 jobs:
   prepare-definitions:
@@ -39,10 +41,10 @@ jobs:
 
     steps:
       -
-        name: Checkout ${{ github.repository }}, branch 'docker-library'
+        name: Checkout ${{ github.repository }}, branch '${{ matrix.version_major }}'
         uses: actions/checkout@v4
         with:
-          ref: docker-library
+          ref: ${{ matrix.version_major }}
           fetch-depth: 0 # Checkout all commits
 
       -
@@ -55,15 +57,17 @@ jobs:
       -
         name: "Get need data for the definition"
         run: |
-          # Containerfile for specific version and image type
-          containerfile=Containerfiles/${{ matrix.version_major }}/Containerfile.${{ matrix.image_types }}
+          # Dockerfile for specific version and image type (let's take platform amd64)
+          platform=amd64
+          dockerfile=${{ matrix.image_types }}/${platform}/Dockerfile
+          test -f ${dockerfile}
 
-          # The recent commit of the Containerfile
-          last_commit=$( git log -1 --format='%H' -- ${containerfile} )
+          # The recent commit of the Dockerfile
+          last_commit=$( git log -1 --format='%H' -- ${dockerfile} )
           echo "commit_hash=${last_commit}" >> $GITHUB_ENV
 
-          # Get tags from the Containerfile
-          tags=$( grep 'Tags:' ${containerfile} | sed "s/^[[:space:]]*#[[:space:]]*Tags: \(.*\)$/\1/" )
+          # Get tags from the Dockerfile
+          tags=$( grep 'Tags:' ${dockerfile} | sed "s/^[[:space:]]*#[[:space:]]*Tags: \(.*\)$/\1/" )
           echo "tags=${tags}" >> $GITHUB_ENV
 
           [ -z "$last_commit-x" -o -z "$tags-x" ] && false
@@ -208,6 +212,7 @@ jobs:
           prs=$(gh pr list \
           --repo ${{ env.docker_library }} \
           --base master \
+          --author ${{ env.library_owner}} \
           --json title \
           --jq 'length')
 


### PR DESCRIPTION
Implement root file-system extracting from images.

Remove "Collect and save changed Containerfile(s) used by Docker Official Library" job from the "Build, test and push to the Client Library" workflow. It is now part of the "Deploy version_major images_type images" job.

Update README.md.