### PR TITLE
Enhance syncing of almalinux/docker-library-official-images with upstream

### DIFF
--- a/.github/workflows/publish-docker-library.yml
+++ b/.github/workflows/publish-docker-library.yml
@@ -109,6 +109,14 @@ jobs:
 
     steps:
       -
+        name: "Sync ${{ env.local_library }} with ${{ env.docker_library }}, branch 'master'"
+        run: |
+          # Sync ${{ env.local_library }} with ${{ env.docker_library }}, branch 'master'
+
+          gh auth login --with-token < <(echo ${{ secrets.GIT_HUB_TOKEN }})
+          gh repo sync ${{ env.local_library }} --force --source ${{ env.docker_library }} --branch master
+
+      -
         name: Checkout ${{ env.local_library }}, branch 'master'
         uses: actions/checkout@v4
         with:
@@ -116,27 +124,6 @@ jobs:
           path: official-images
           token: ${{ secrets.GIT_HUB_TOKEN }}
           fetch-depth: 0 # Checkout all commits
-
-      -
-        name: "Sync ${{ env.local_library }} with ${{ env.docker_library }}"
-        run: |
-          # sync ${{ env.local_library }}
-          cd official-images
-
-          git remote add upstream https://github.com/${{ env.docker_library }}.git
-          git fetch upstream
-          git checkout master
-
-          ret=0
-          git rebase upstream/master || ret=$?
-
-          if [ $ret -ne 0 ]; then
-            echo "Abort the rebase, reset last commit, stash it and try to rebase again ..."
-            git rebase --abort
-            git reset HEAD~1
-            git stash
-            git rebase upstream/master
-          fi
 
       # Download uploaded above 'official-images/library/almalinux.*'
       - uses: actions/download-artifact@v4
@@ -194,7 +181,8 @@ jobs:
         with:
           cwd: official-images
           default_author: user_info
-          message: "Almalinux auto-update - ${{ env.date_stamp }} ${{ env.time_stamp }}"
+          pull: '--rebase --autostash'
+          message: "AlmaLinux auto-update - ${{ env.date_stamp }} ${{ env.time_stamp }}"
           push: true
 
       -

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Publish images to the Docker Library
 └── Create Pull Request with the new definition file
     ├── Set up job
     ├── Checkout official-images, branch 'master'
-    ├── Sync official-images with docker-library/official-images
+    ├── Sync official-images with docker-library/official-images, branch 'master'
     ├── Download all definitions
     ├── Create head of official-images/library/almalinux
     ├── Merge definitions into official-images/library/almalinux
@@ -721,7 +721,7 @@ That's your fork of [docker-library/official-images](https://github.com/docker-l
 
 #### Step: Sync *official-images* with upstream
 
-The step is written in bash. It adds the [official-images upstream](https://github.com/docker-library/official-images) repository, sets a local 'master' branch to track the corresponding one from the upstream, and tries to rebase with the 'upstream/master'.
+The step is written in bash. It uses GitHub CLI to sync the [docker-library-official-images](https://github.com/AlmaLinux/docker-library-official-images) with the [official-images upstream](https://github.com/docker-library/official-images) repository.
 
 #### Step: Download all definitions
 
@@ -749,8 +749,9 @@ Uses [EndBug/add-and-commit@v9](https://github.com/marketplace/actions/add-commi
 
 The commit message is:
 ```yaml
-Almalinux auto-update - ${{ env.date_stamp }} ${{ env.time_stamp }}.
+AlmaLinux auto-update - ${{ env.date_stamp }} ${{ env.time_stamp }}.
 ```
+> It will try to pull recent changes (before push) with `--rebase --autostash`
 
 #### Step: Create Pull Request for *official-images/library/almalinux*
 


### PR DESCRIPTION
Use GitHub CLI to sync
Pull with '--rebase --autostash' before push

Update README.md