### PR TITLE
Add new job to do almalinux/container-images repository size optimization

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v4
 
       -
-        name: Checkout ${{ github.repository }}, branch 'docker-library', path '${{ inputs.version_major }}'
+        name: Checkout ${{ github.repository }}, branch '${{ inputs.version_major }}', path '${{ inputs.version_major }}'
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version_major }}
@@ -352,6 +352,19 @@ jobs:
             cat ${dockerfile}
           done
 
+      -
+        name: "Prepare time stamp"
+        id: time_stamp
+        run: |
+          # time stamp
+          time_stamp=$(date -u '+%H:%M:%S')
+          echo "time_stamp=${time_stamp}" >> $GITHUB_ENV
+          echo "time_stamp=${time_stamp}" >> "$GITHUB_OUTPUT"
+          [ -z "$time_stamp-x" ] && false
+
+          # [Debug]
+          echo "time_stamp=${time_stamp}"
+
       # Commit '${version_major}/${image_types}/${arch}/*'
       -
         name: "Commit and push ${{ matrix.image_types }}/*/* Dockerfile and RootFS (branch ${{ inputs.version_major }})"
@@ -363,5 +376,67 @@ jobs:
           new_branch: ${{ inputs.version_major }}
           cwd: ${{ inputs.version_major }}
           pull: '--rebase --autostash'
-          message: "AlmaLinux ${{ inputs.version_major }} ${{ matrix.image_types }} image built as of ${{ env.date_stamp }} (generated on ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          message: "AlmaLinux ${{ inputs.version_major }} ${{ matrix.image_types }} - ${{ env.date_stamp }} ${{ env.time_stamp }} (generated on ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           push: true
+
+    outputs:
+      date_stamp: ${{ steps.date_stamp.outputs.date_stamp }}
+      time_stamp: ${{ steps.time_stamp.outputs.time_stamp }}
+
+  optimize-repo-size:
+    # 'default' or 'minimal' images only and 'Push to production' is checked
+    if: ( inputs.type_default || inputs.type_minimal ) && inputs.production
+    name: Optimize ${{ github.repository }} size of the branch '${{ inputs.version_major }}'
+    runs-on: ubuntu-latest
+    needs:
+      - build-test-push
+    steps:
+
+      -
+        name: Checkout ${{ github.repository }}, branch '${{ inputs.version_major }}', path '${{ inputs.version_major }}'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version_major }}
+          path: ${{ inputs.version_major }}
+
+      -
+        name: Optimize size of branch the '${{ inputs.version_major }}'
+        run: |
+          date_stamp=${{ needs.build-test-push.outputs.date_stamp }}
+          cd ${{ inputs.version_major }}
+
+          echo "Prepare new branch 'tmp' based on ${{ inputs.version_major }}"
+          git checkout -b tmp
+
+          echo "Delete local branch '${{ inputs.version_major }}'"
+          git branch -D ${{ inputs.version_major }}
+
+          echo "Preserve resent data"
+          mkdir ../tmp-${date_stamp}
+
+          mv ./default ../tmp-${date_stamp}/
+          mv ./minimal ../tmp-${date_stamp}/
+
+          echo "Crete orphan branch '${{ inputs.version_major }}'"
+          git checkout --orphan ${{ inputs.version_major }}
+
+          echo "Clean up"
+          git rm --cached -r .
+          rm -rf ./default
+          rm -rf ./minimal
+
+          echo "Restore resent data"
+          mv ../tmp-${date_stamp}/default ./
+          mv ../tmp-${date_stamp}/minimal ./
+
+          echo "[Debug]"
+          git status
+
+      -
+        name: Commit and push ${{ github.repository }}, branch '${{ inputs.version_major }}'
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: user_info
+          message: "Update AlmaLinux ${{ inputs.version_major }} - ${{ needs.build-test-push.outputs.date_stamp }} ${{ needs.build-test-push.outputs.time_stamp }} (generated on ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          push: '--force --set-upstream origin ${{ inputs.version_major }}'
+          cwd: ${{ inputs.version_major }}

--- a/README.md
+++ b/README.md
@@ -416,34 +416,38 @@ Tree illustration of the workflow Jobs and Steps for AlmaLinux 9 minimal image:
 ```
     Build, test and push to the Client Library
     │
-    └── Deploy 9 minimal images
-        ├── Set up job
-        ├── DeployPrepare AlmaLinux Minor version number
-        ├── Prepare date stamp
-        ├── Generate list of Docker images to use as base name for tags
-        ├── Enable containerd image store on Docker Engine
-        ├── Checkout _container-images, branch 'main'
-        ├── Checkout _container-images, branch '9', path '9'
-        ├── Set up QEMU
-        ├── Set up Docker Buildx
-        ├── Login to Docker.io
-        ├── Login to Quay.io
-        ├── Login to Ghcr.io
-        ├── Generate tags and prepare metadata to build and push
-        ├── Build images
-        ├── Test images
-        ├── Push images to Client Library
-        ├── Extract RootFS (default and minimal only)
-        ├── Change date stamp in Dockerfile (default and minimal only)
-        ├── Commit and push minimal/*/* Dockerfile and RootFS (branch 9)"
-        ├── Post Push images to Client Library
-        ├── Post Build images
-        ├── Post Login to Ghcr.io
-        ├── Post Set up Docker Buildx
-        ├── Post Checkout _container-images, branch '9', path '9'
-        ├── Post Checkout _container-images, branch 'main'
-        └── Complete job
-
+    ├── Deploy 9 minimal images
+    │   ├── Set up job
+    │   ├── DeployPrepare AlmaLinux Minor version number
+    │   ├── Prepare date stamp
+    │   ├── Generate list of Docker images to use as base name for tags
+    │   ├── Enable containerd image store on Docker Engine
+    │   ├── Checkout _container-images, branch 'main'
+    │   ├── Checkout _container-images, branch '9', path '9'
+    │   ├── Set up QEMU
+    │   ├── Set up Docker Buildx
+    │   ├── Login to Docker.io
+    │   ├── Login to Quay.io
+    │   ├── Login to Ghcr.io
+    │   ├── Generate tags and prepare metadata to build and push
+    │   ├── Build images
+    │   ├── Test images
+    │   ├── Push images to Client Library
+    │   ├── Extract RootFS (default and minimal only)
+    │   ├── Change date stamp in Dockerfile (default and minimal only)
+    │   ├── Commit and push minimal/*/* Dockerfile and RootFS (branch 9)"
+    │   ├── Post Push images to Client Library
+    │   ├── Post Build images
+    │   ├── Post Login to Ghcr.io
+    │   ├── Post Set up Docker Buildx
+    │   ├── Post Checkout _container-images, branch '9', path '9'
+    │   ├── Post Checkout _container-images, branch 'main'
+    │   └── Complete job
+    │
+    └── Optimize almalinux/container-images size of the branch '9'
+        ├── Checkout almalinux/container-images, branch '9', path '9'
+        ├── Optimize size of branch the '9'
+        └── Commit and push almalinux/container-images, branch '9'
 ```
 
 ### Inputs
@@ -627,6 +631,30 @@ The commit message is:
 AlmaLinux ${version_major}-${images_type} image build as of ${date_stamp} (with ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 ```
 It includes the AlmaLinux version major, image type, build date, and reference to this GitHub Action.
+
+### Optimize almalinux/container-images size of the branch '${version_major}'
+
+❗ Skip the job if the image type is not 'default' or 'minimal', or '*Push to production registries*' is not checked (`inputs.production` set to `false`.)
+
+#### Checkout almalinux/container-images, branch '${version_major}', path '${version_major}'
+
+The [actions/checkout@v4](https://github.com/actions/checkout/) checkouts *container-images* into branch '${version_major}'. The repository directory is located at `/home/runner/work/container-images/container-images` and its subdirectory is named '${version_major}'. All commits for the branch are checkout with `fetch-depth: 0`.
+
+#### Optimize size of branch the '${version_major}'
+
+This step is written in bash and is designed to:
+- preserves 'default' and 'minimal' folders with Dockerfiles and RootFSs into `../tmp-${date_stamp}` folder
+- checkouts into new local 'tmp' branch
+- removes local ${version_major} branch
+- checkouts into orphan ${version_major} branch
+- restores 'default' and 'minimal' folders into the orphan branch placeholder
+
+#### Commit and push almalinux/container-images, branch '${version_major}'
+
+Uses [EndBug/add-and-commit@v9](https://github.com/marketplace/actions/add-commit) to commit and push Dockerfiles and RootFSs which were prepared on previous step.
+The following options are used to push:
+- `--force` - to rewrite history
+- `--set-upstream origin ${version_major}` - to set upstream branch (as new one is orphan)
 
 ## Publish images to the Docker Library
 


### PR DESCRIPTION
- prepare new branch 'tmp' based on the recent data from 8 or 9 branch
- copy 'default' and 'minimal' data (Dockerfile and RootFS)
- delete local 8 or 9 branch, and create orphan one

Update README.md