### PR TITLE
Use ubuntu-24.04 runner instead of ubuntu-latest

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -66,7 +66,7 @@ env:
 jobs:
   build-test-push:
     name: Deploy ${{ inputs.version_major }} ${{ matrix.image_types }} images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -209,17 +209,43 @@ jobs:
             type=raw,value=${{ inputs.version_major }}${{ env.version_minor }}-${{ env.date_stamp }},enable=true
 
       -
-        name: Build images
+        name: Build images and push to Client Library
         id: build-images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           provenance: false
           context: "{{defaultContext}}:Containerfiles/${{ inputs.version_major }}"
           file: ./Containerfile.${{ matrix.image_types }}
           platforms: ${{ env.platforms }}
-          push: false
-          load: true
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      -
+        name: Prepare pull tag
+        # The tag is used to pull images from selected registry
+        id: prepare-tag
+        run: |
+          REGISTRIES="${{ env.registries }}"
+          for REGISTRY in ${REGISTRIES//,/ }; do
+            # Take the first registry if not default image
+            [ "${{ matrix.image_types }}" != "default" ] && break
+
+            # Take any registry except 'docker.io' if default image
+            [[ $REGISTRY != *'docker.io'* ]] && break
+
+            unset REGISTRY
+          done
+          [ "x${REGISTRY}" = "x" ] && exit 1
+
+          # 'default' images goes to $REGISTRY/almalinux
+          [ "${{ matrix.image_types }}" = "default" ] \
+            && IMAGE_NAME="$REGISTRY/almalinux" \
+            || IMAGE_NAME="$REGISTRY/${{ inputs.version_major }}-${{ matrix.image_types }}"
+
+          PULL_TAG="${IMAGE_NAME}:${{ inputs.version_major }}${{ env.version_minor }}-${{ env.date_stamp }}"
+
+          echo "[Debug] ${PULL_TAG}"
+          echo "PULL_TAG=${PULL_TAG}" >> $GITHUB_ENV
 
       -
         name: Test images
@@ -230,23 +256,13 @@ jobs:
           for platform in ${platforms//,/ }; do
             echo "Testing AlmaLinux ${{ inputs.version_major }} ${{ matrix.image_types }} for ${platform} image:"
 
-            docker run --platform=${platform} ${{ steps.build-images.outputs.digest }} /bin/bash -c " \
+            docker pull --platform=${platform} ${{ env.PULL_TAG }}
+
+            docker run --platform=${platform} ${{ env.PULL_TAG }} /bin/bash -c " \
             uname -m \
             && cat /etc/almalinux-release \
             && ( test "${{ matrix.image_types }}" != "micro" && rpm -q gpg-pubkey) || true "
           done
-
-      -
-        name: Push images to Client Library
-        id: push-images
-        uses: docker/build-push-action@v5
-        with:
-          provenance: false
-          context: "{{defaultContext}}:Containerfiles/${{ inputs.version_major }}"
-          file: ./Containerfile.${{ matrix.image_types }}
-          platforms: ${{ env.platforms }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
 
       -
         name: Extract RootFS (default and minimal only)
@@ -270,7 +286,7 @@ jobs:
           cd ${path}
 
           # Produce a tarred repository and save it to the "tar file".
-          docker save ${{ steps.build-images.outputs.digest }} -o ${tar_name}
+          docker save ${{ env.PULL_TAG }} -o ${tar_name}
 
           # Extract the "tar file"
           tar xf ${tar_name}
@@ -397,7 +413,7 @@ jobs:
     # 'default' or 'minimal' images only and 'Push to production' is checked
     if: ( inputs.type_default || inputs.type_minimal ) && inputs.production
     name: Optimize size of repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-test-push
     steps:

--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ Tree illustration of the workflow Jobs and Steps for AlmaLinux 9 minimal image:
     │   ├── Login to Quay.io
     │   ├── Login to Ghcr.io
     │   ├── Generate tags and prepare metadata to build and push
-    │   ├── Build images
+    │   ├── Build images and push to Client Library
+    │   ├── Prepare pull tag
     │   ├── Test images
-    │   ├── Push images to Client Library
     │   ├── Extract RootFS (default and minimal only)
     │   ├── Change date stamp in Dockerfile (default and minimal only)
     │   ├── Commit and push minimal/*/* Dockerfile and RootFS (branch 9)"
@@ -559,30 +559,38 @@ The [docker/metadata-action@v5](https://github.com/docker/metadata-action) is us
           "quay.io/***/8-minimal:8.9-20240319",
         ],
 ```
-#### Step: Build images
+#### Step: Build images and push to Client Library
 
-The [docker/build-push-action@v5](https://github.com/docker/build-push-action) is used to build images. This step builds the images from corresponding [`Containerfile`](https://github.com/AlmaLinux/container-images/tree/main/Containerfiles), for specified `env.platforms` and uses tags from the previous step. After the successful building, the images are loaded into docker, but not pushed yet as they need to be tested first. AlmaLinux 8 minimal images `buildx` looks like this:
+The [docker/build-push-action@v5](https://github.com/docker/build-push-action) is used to build images. This step builds the images from corresponding [`Containerfile`](https://github.com/AlmaLinux/container-images/tree/main/Containerfiles), for specified `env.platforms` and uses tags from the previous step. After the successful building, images pushed built into *Client Library*.. AlmaLinux 8 minimal images `buildx` looks like this:
 ```sh
 /usr/bin/docker buildx build --file ./Containerfile.minimal ... \
  --platform linux/amd64,linux/ppc64le,linux/s390x,linux/arm64 \
  --provenance false ... \
  --tag docker.io/***/8-minimal:latest --tag docker.io/***/8-minimal:8 --tag docker.io/***/8-minimal:8.9 --tag docker.io/***/8-minimal:8.9-20240319 --tag quay.io/***/8-minimal:latest --tag quay.io/***/8-minimal:8 --tag quay.io/***/8-minimal:8.9 --tag quay.io/***/8-minimal:8.9-20240319 \
- --load \
  --metadata-file /home/runner/work/_temp/docker-actions-toolkit-*/metadata-file \
+ --push \
  https://github.com/***/container-images.git#270a6d3fd433cfa6c3e1fff5896a92d1ae2896be:Containerfiles/8
 ```
 `provenance: false` is to disable the [Provenance attestations](https://docs.docker.com/build/attestations/slsa-provenance/) as Quay.io registry doesn't support such kind of images data.
 
+#### Step: Prepare pull tag
+
+Prepare tag to pull images from selected registry. The tag value looks like:
+```sh
+REGISTRY:${version_major}.${version_minor}-${date_stamp}
+```
+Examples: `docker.io/***/8-minimal:8.9-20240319`, `quay.io/***/almalinux:8.9-20240319` or `ghcr.io/***/almalinux:8.9-20240319` if 'default' image
+
+The `REGISTRY` is the first registry in the list if not 'default' image, or any other registry except 'docker.io', if 'default' image
+
+The tag is set into corresponded `PULL_TAG` environment variable.
+
 #### Step: Test images
 
-Every image can be tested separately for each type and platform as each image is loaded into docker. Docker run images "by digest":
+Every image is tested separately for each type and platform as each image is loaded into docker. Docker run images "by tag":
 ```sh
-docker run --platform=${platform} ${{ steps.build-images.outputs.digest }}
+docker run --platform=${platform} ${{ env.PULL_TAG }} ...
 ```
-
-#### Step: Push images to Client Library
-
-The [docker/build-push-action@v5](https://github.com/docker/build-push-action) is used. This step pushes built images into *Client Library*. The options are the same as for **Build images** step.
 
 #### Step: Extract RootFS (default and minimal only)
 


### PR DESCRIPTION
Change build and push procedure:
 - build and push to registries with one step
 - then select registry and prepare pull tag. Take the first registry in list if not 'default' image, or any registry except 'docker.io' othervise
 - pull images for each platform using the tag, and test them
 - save pulled images, and extract rootfs (for default and minimal)

Update README.md