### PR TITLE
AlmaLinux release 10.0 build

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -66,7 +66,7 @@ env:
   # List of versions to build on schedule
   # TODO: add 10 when it is released
   # Kitten should not be built on schedule
-  versions_list: '"8", "9"'
+  versions_list: '"8", "9", "10"'
 
   # List image types to build on schedule
   image_types: '"default", "minimal", "micro", "base", "init"'

--- a/Containerfiles/10/Containerfile.base
+++ b/Containerfiles/10/Containerfile.base
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/ykohut/almalinux:10-bootstrap
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.default
+++ b/Containerfiles/10/Containerfile.default
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/ykohut/almalinux:10-bootstrap
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.init
+++ b/Containerfiles/10/Containerfile.init
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/ykohut/almalinux:10-bootstrap
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.micro
+++ b/Containerfiles/10/Containerfile.micro
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/ykohut/almalinux:10-bootstrap
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.minimal
+++ b/Containerfiles/10/Containerfile.minimal
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/ykohut/almalinux:10-bootstrap
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} as system-build
 
 RUN mkdir /mnt/sys-root; \


### PR DESCRIPTION
Use `quay.io/almalinuxautobot/almalinux:10` as base for images building

CI: add AlmaLinux release 10.0 images to build on schedule