### PR TITLE
AlmaLinux 9 linux/i386 images:

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -192,6 +192,8 @@ jobs:
             platforms="${{ env.platforms }}"
             [[ "${{ matrix.version_major }}" =~ "10" ]] && \
               platforms="linux/amd64/v2, ${platforms}"
+            [[ "${{ matrix.version_major }}" =~ "9" ]] && \
+              platforms="linux/i386, ${platforms}"
             echo "platforms=${platforms}" >> $GITHUB_ENV
 
             # Registries
@@ -331,6 +333,7 @@ jobs:
           for platform in ${platforms//,/ }; do
             echo "Testing AlmaLinux ${{ matrix.version_major }} ${{ matrix.image_types }} for ${platform} image:"
 
+            # TODO: machine hardware name is x86_64 on linux/i386 platform
             docker run --platform=${platform} ${{ steps.build-images.outputs.digest }} /bin/bash -c " \
             uname -m \
             && cat /etc/almalinux-release \
@@ -422,6 +425,8 @@ jobs:
               platform=
               docker rmi rootfs
               case ${arch} in
+                i686)
+                  platform=i386;;
                 x86_64)
                   platform=amd64;;
                 x86_64_v2)

--- a/Containerfiles/9/Containerfile.base
+++ b/Containerfiles/9/Containerfile.base
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:9
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:9
 FROM ${SYSBASE} as system-build
 
 RUN mkdir -p /mnt/sys-root; \
@@ -72,6 +72,14 @@ RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/
     ln -s ../usr/share/zoneinfo/UTC localtime ;
 
 RUN systemd-tmpfiles --root=/mnt/sys-root --create /usr/lib/tmpfiles.d/rootfiles.conf
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+    sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+    -e 's/# baseurl=/baseurl=/g' \
+    -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+    -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch as stage2
 

--- a/Containerfiles/9/Containerfile.default
+++ b/Containerfiles/9/Containerfile.default
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:9
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:9
 FROM ${SYSBASE} as system-build
 
 RUN mkdir /mnt/sys-root; \
@@ -76,6 +76,14 @@ RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/
     ln -s ../usr/share/zoneinfo/UTC localtime ;
 
 RUN systemd-tmpfiles --root=/mnt/sys-root --create /usr/lib/tmpfiles.d/rootfiles.conf
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+    sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+    -e 's/# baseurl=/baseurl=/g' \
+    -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+    -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 # Almalinux default build
 FROM scratch as stage2

--- a/Containerfiles/9/Containerfile.init
+++ b/Containerfiles/9/Containerfile.init
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:9
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:9
 FROM ${SYSBASE} as system-build
 
 RUN mkdir /mnt/sys-root; \
@@ -79,6 +79,14 @@ RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/
     ln -s ../usr/share/zoneinfo/UTC localtime ;
 
 RUN systemd-tmpfiles --root=/mnt/sys-root --create /usr/lib/tmpfiles.d/rootfiles.conf
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+    sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+    -e 's/# baseurl=/baseurl=/g' \
+    -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+    -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch as stage2
 

--- a/Containerfiles/9/Containerfile.micro
+++ b/Containerfiles/9/Containerfile.micro
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:9
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:9
 FROM ${SYSBASE} as system-build
 
 RUN mkdir -p /mnt/sys-root; \
@@ -31,6 +31,14 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     ln -s ../usr/share/zoneinfo/UTC localtime
 
 RUN install -m644 /usr/share/rootfiles/{.bash_logout,.bash_profile,.bashrc,.cshrc,.tcshrc} /mnt/sys-root/root/
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+    sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+    -e 's/# baseurl=/baseurl=/g' \
+    -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+    -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch
 

--- a/Containerfiles/9/Containerfile.minimal
+++ b/Containerfiles/9/Containerfile.minimal
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:9
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:9
 FROM ${SYSBASE} as system-build
 
 RUN mkdir /mnt/sys-root; \
@@ -63,6 +63,14 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     ln -s /usr/lib/systemd/system/multi-user.target default.target
 
 RUN systemd-tmpfiles --root=/mnt/sys-root --create /usr/lib/tmpfiles.d/rootfiles.conf
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+    sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+    -e 's/# baseurl=/baseurl=/g' \
+    -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+    -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 # Almalinux minimal build
 FROM scratch


### PR DESCRIPTION
- temporary use quay.io/almalinuxautobot/almalinux:9 as SYSBASE
- use ARG TARGETPLATFORM
- switch into baseurl and hardcode $basearch into i386 if TARGETPLATFORM is linux/i386

CI:
- add linux/i386 to the platforms list if AlmaLinux 9
- note that machine hardware name is x86_64 on linux/i386 platform