### PR TITLE
AlmaLinux 8 linux/386 images:

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -190,10 +190,12 @@ jobs:
         run: |
             # Platforms
             platforms="${{ env.platforms }}"
-            [[ "${{ matrix.version_major }}" =~ "10" ]] && \
-              platforms="linux/amd64/v2, ${platforms}"
-            [[ "${{ matrix.version_major }}" =~ "9" ]] && \
-              platforms="linux/386, ${platforms}"
+            case ${{ matrix.version_major }} in
+              8|9)
+                platforms="linux/386, ${platforms}" ;;
+              10*)
+                platforms="linux/amd64/v2, ${platforms}" ;;
+            esac
             echo "platforms=${platforms}" >> $GITHUB_ENV
 
             # Registries

--- a/Containerfiles/8/Containerfile.base
+++ b/Containerfiles/8/Containerfile.base
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:8
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:8
 FROM ${SYSBASE} as system-build
 
 RUN mkdir -p /mnt/sys-root; \
@@ -49,6 +49,14 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/resolv.conf; \
     touch /mnt/sys-root/etc/hostname
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+        sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+        -e 's/# baseurl=/baseurl=/g' \
+        -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+        -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch as stage2
 

--- a/Containerfiles/8/Containerfile.default
+++ b/Containerfiles/8/Containerfile.default
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:8
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:8
 FROM ${SYSBASE} as system-build
 
 RUN mkdir /mnt/sys-root; \
@@ -50,6 +50,14 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* ; \
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/resolv.conf; \
     touch /mnt/sys-root/etc/hostname
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+        sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+        -e 's/# baseurl=/baseurl=/g' \
+        -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+        -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch as stage2
 COPY --from=system-build /mnt/sys-root/ /

--- a/Containerfiles/8/Containerfile.init
+++ b/Containerfiles/8/Containerfile.init
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:8
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:8
 FROM ${SYSBASE} as system-build
 
 RUN mkdir -p /mnt/sys-root; \
@@ -50,6 +50,14 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/resolv.conf; \
     touch /mnt/sys-root/etc/hostname
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+        sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+        -e 's/# baseurl=/baseurl=/g' \
+        -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+        -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch  as stage2
 

--- a/Containerfiles/8/Containerfile.micro
+++ b/Containerfiles/8/Containerfile.micro
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:8
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:8
 FROM ${SYSBASE} as system-build
 
 RUN mkdir -p /mnt/sys-root; \
@@ -28,6 +28,14 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     cd /mnt/sys-root/etc ; \
     ln -s ../usr/share/zoneinfo/UTC localtime
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+        sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+        -e 's/# baseurl=/baseurl=/g' \
+        -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+        -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 FROM scratch
 

--- a/Containerfiles/8/Containerfile.minimal
+++ b/Containerfiles/8/Containerfile.minimal
@@ -1,4 +1,4 @@
-ARG SYSBASE=almalinux:8
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:8
 FROM ${SYSBASE} as builder
 
 RUN mkdir /mnt/sys-root; \
@@ -40,6 +40,14 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/hostname; \
     cd /mnt/sys-root/etc ; \
     ln -s ../usr/share/zoneinfo/UTC localtime
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+        sed -i -e 's/mirrorlist=/# mirrorlist=/g' \
+        -e 's/# baseurl=/baseurl=/g' \
+        -e 's/repo\.almalinux\.org\/almalinux/vault.almalinux.org/g' \
+        -e 's/\$basearch/i686/g' /mnt/sys-root/etc/yum.repos.d/*.repo; \
+fi
 
 # Almalinux minimal build
 FROM scratch


### PR DESCRIPTION
- temporary use quay.io/almalinuxautobot/almalinux:8 as SYSBASE
- use ARG TARGETPLATFORM
- switch into baseurl and hardcode $basearch into i386 if TARGETPLATFORM is linux/i386

CI:
- add linux/i386 to the platforms list if AlmaLinux 8