### PR TITLE
Add google droid fonts to toolbox images (10, 10-kitten)

### DIFF
--- a/Containerfiles/10-kitten/Containerfile.toolbox
+++ b/Containerfiles/10-kitten/Containerfile.toolbox
@@ -93,6 +93,7 @@ RUN rm /etc/rpm/macros.image-language-conf; \
     bash-completion \
     bzip2 \
     dejavu-sans-fonts \
+    google-droid-*-fonts \
     diffutils \
     dnf-plugins-core \
     flatpak-spawn \

--- a/Containerfiles/10/Containerfile.toolbox
+++ b/Containerfiles/10/Containerfile.toolbox
@@ -93,6 +93,7 @@ RUN rm /etc/rpm/macros.image-language-conf; \
     bash-completion \
     bzip2 \
     dejavu-sans-fonts \
+    google-droid-*-fonts \
     diffutils \
     dnf-plugins-core \
     flatpak-spawn \


### PR DESCRIPTION
This fixes font rendering issues with VSCode when used in a toolbox container