### PR TITLE
AlmaLinux Kitten 10 linux/386 images

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -202,7 +202,7 @@ jobs:
               10)
                 platforms="linux/amd64/v2, ${platforms}" ;;
               10-kitten)
-                platforms="linux/riscv64, linux/amd64/v2, ${platforms}" ;;
+                platforms="linux/386, linux/riscv64, linux/amd64/v2, ${platforms}" ;;
             esac
             echo "platforms=${platforms}" >> $GITHUB_ENV
 

--- a/Containerfiles/10-kitten/Containerfile.base
+++ b/Containerfiles/10-kitten/Containerfile.base
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10-kitten
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10-kitten
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \

--- a/Containerfiles/10-kitten/Containerfile.default
+++ b/Containerfiles/10-kitten/Containerfile.default
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10-kitten
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10-kitten
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10-kitten/Containerfile.init
+++ b/Containerfiles/10-kitten/Containerfile.init
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10-kitten
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10-kitten
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10-kitten/Containerfile.micro
+++ b/Containerfiles/10-kitten/Containerfile.micro
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10-kitten
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10-kitten
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \

--- a/Containerfiles/10-kitten/Containerfile.minimal
+++ b/Containerfiles/10-kitten/Containerfile.minimal
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10-kitten
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10-kitten
 FROM ${SYSBASE} as system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10-kitten/Containerfile.toolbox
+++ b/Containerfiles/10-kitten/Containerfile.toolbox
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10-kitten
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10-kitten
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \


### PR DESCRIPTION
- Temporary use quay.io/almalinuxautobot/almalinux:10-kitten as SYSBASE
- CI:
 - add linux/386 to the platforms list