### PR TITLE
Add python3-dnf-plugins-core to base and default images

### DIFF
--- a/Containerfiles/10-kitten/Containerfile.base
+++ b/Containerfiles/10-kitten/Containerfile.base
@@ -15,6 +15,7 @@ RUN mkdir -p /mnt/sys-root; \
     gzip \
     libcurl-minimal \
     libusbx \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \

--- a/Containerfiles/10-kitten/Containerfile.default
+++ b/Containerfiles/10-kitten/Containerfile.default
@@ -21,6 +21,7 @@ RUN mkdir /mnt/sys-root; \
     krb5-libs \
     less \
     libcurl-minimal \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \

--- a/Containerfiles/10/Containerfile.base
+++ b/Containerfiles/10/Containerfile.base
@@ -15,6 +15,7 @@ RUN mkdir -p /mnt/sys-root; \
     gzip \
     libcurl-minimal \
     libusbx \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \

--- a/Containerfiles/10/Containerfile.default
+++ b/Containerfiles/10/Containerfile.default
@@ -21,6 +21,7 @@ RUN mkdir /mnt/sys-root; \
     krb5-libs \
     less \
     libcurl-minimal \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \

--- a/Containerfiles/8/Containerfile.base
+++ b/Containerfiles/8/Containerfile.base
@@ -14,6 +14,7 @@ RUN mkdir -p /mnt/sys-root; \
     langpacks-en \
     libuser \
     passwd \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \

--- a/Containerfiles/8/Containerfile.default
+++ b/Containerfiles/8/Containerfile.default
@@ -17,6 +17,7 @@ RUN mkdir /mnt/sys-root; \
     langpacks-en \
     less \
     libcurl-minimal \
+    python3-dnf-plugins-core \
     rootfiles \
     tar \
     vim-minimal \

--- a/Containerfiles/9/Containerfile.base
+++ b/Containerfiles/9/Containerfile.base
@@ -15,6 +15,7 @@ RUN mkdir -p /mnt/sys-root; \
     gzip \
     libcurl-minimal \
     libusbx \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \

--- a/Containerfiles/9/Containerfile.default
+++ b/Containerfiles/9/Containerfile.default
@@ -20,6 +20,7 @@ RUN mkdir /mnt/sys-root; \
     krb5-libs \
     less \
     libcurl-minimal \
+    python3-dnf-plugins-core \
     rootfiles \
     systemd \
     tar \


### PR DESCRIPTION
## Summary
- Add `python3-dnf-plugins-core` package to all base and default container images
- Covers AlmaLinux 8, 9, 10, and 10-kitten

## Changed files
- `Containerfiles/8/Containerfile.base`
- `Containerfiles/8/Containerfile.default`
- `Containerfiles/9/Containerfile.base`
- `Containerfiles/9/Containerfile.default`
- `Containerfiles/10/Containerfile.base`
- `Containerfiles/10/Containerfile.default`
- `Containerfiles/10-kitten/Containerfile.base`
- `Containerfiles/10-kitten/Containerfile.default`