### PR TITLE
AlmaLinux 10 linux/386 images

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -200,7 +200,7 @@ jobs:
               8|9)
                 platforms="linux/386, ${platforms}" ;;
               10)
-                platforms="linux/amd64/v2, ${platforms}" ;;
+                platforms="linux/386, linux/amd64/v2, ${platforms}" ;;
               10-kitten)
                 platforms="linux/386, linux/riscv64, linux/amd64/v2, ${platforms}" ;;
             esac

--- a/Containerfiles/10/Containerfile.base
+++ b/Containerfiles/10/Containerfile.base
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.default
+++ b/Containerfiles/10/Containerfile.default
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.init
+++ b/Containerfiles/10/Containerfile.init
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.micro
+++ b/Containerfiles/10/Containerfile.micro
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.minimal
+++ b/Containerfiles/10/Containerfile.minimal
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir /mnt/sys-root; \

--- a/Containerfiles/10/Containerfile.toolbox
+++ b/Containerfiles/10/Containerfile.toolbox
@@ -1,4 +1,4 @@
-ARG SYSBASE=quay.io/almalinuxorg/almalinux:10
+ARG SYSBASE=quay.io/almalinuxautobot/almalinux:10
 FROM ${SYSBASE} AS system-build
 
 RUN mkdir -p /mnt/sys-root; \


### PR DESCRIPTION
- Temporary use `quay.io/almalinuxautobot/almalinux:10` as SYSBASE
- CI:
 - add `linux/386` to the platforms list