### PR TITLE
AlmaLinux 10 linux/386 images

### DIFF
--- a/default/386/Dockerfile
+++ b/default/386/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: latest, 10, 10.2, 10.2-20260526
+FROM scratch
+ADD almalinux-10-default-386.tar.xz /
+
+CMD ["/bin/bash"]

--- a/docker-library-definition.tmpl
+++ b/docker-library-definition.tmpl
@@ -3,6 +3,7 @@ GitFetch: refs/heads/{{ .version_major }}
 GitCommit: {{ .commit_hash }}
 amd64-Directory: {{ .image_type }}/amd64/
 arm64v8-Directory: {{ .image_type }}/arm64/
+i386-Directory: {{ .image_type }}/386/
 ppc64le-Directory: {{ .image_type }}/ppc64le/
 s390x-Directory: {{ .image_type }}/s390x/
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm64v8, i386, ppc64le, s390x

--- a/minimal/386/Dockerfile
+++ b/minimal/386/Dockerfile
@@ -1,0 +1,5 @@
+# Tags: minimal, 10-minimal, 10.2-minimal, 10.2-minimal-20260526
+FROM scratch
+ADD almalinux-10-minimal-386.tar.xz /
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
- add placeholder of i386 default and minimal rootfs
- Docker Official to build i386 architecture